### PR TITLE
Reenable creating the `zk/zkey` directory if not present.

### DIFF
--- a/scripts/circuits.sh
+++ b/scripts/circuits.sh
@@ -6,7 +6,7 @@ set -e
 # ... circuit-specific stuff
 
 # if zk/zkey does not exist, make folder
-# [ -d zk/zkey ] || mkdir zk/zkey
+[ -d zk/zkey ] || mkdir zk/zkey
 
 # Compile circuits
 circom zk/circuits/board.circom -o zk/ --r1cs --wasm


### PR DESCRIPTION
When running `yarn setup`, the following error occurred. 
```bash
snarkjs groth16 setup zk/board.r1cs zk/ptau/pot15_final.ptau zk/zkey/board_final.zkey
[ERROR] snarkJS: [Error: ENOENT: no such file or directory, open 'zk/zkey/board_final.zkey'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: 'zk/zkey/board_final.zkey'
}
error Command failed with exit code 1.
```

Reenabling making the `zk/zkey` directory before running the groth16 setup appears to resolve the issue.